### PR TITLE
Update RC2 bundler version

### DIFF
--- a/rc2/Dockerfile
+++ b/rc2/Dockerfile
@@ -2,7 +2,7 @@ FROM dleemoo/app-2.3.1:latest
 
 MAINTAINER Leonardo Lobo Lima <dleemoo@gmail.com>
 
-ENV BUNDLER_VERSION=1.15.1 \
+ENV BUNDLER_VERSION=1.15.3 \
     PG_DOWNLOAD_SHA256=a6856099959bfff7cf0889b0e637b0f04642e8a9e8cbfa3f92555a03ef3b2448
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Keeping up-to-date with production.

_Changes since last version used (1.15.1):_

## 1.15.3 (2017-07-21)

Bugfixes:

  - ensure that empty strings passed to `bundle config` are serialized & parsed properly (bundler/bundler#5881, @segiddins)
  - avoid printing an outdated version warning when running a parseable command (@segiddins)

## 1.15.2 (2017-07-17)

Features:

  - new gemfiles created by bundler will include an explicit `github` git source that uses `https` (@segiddins)

Bugfixes:

  - inline gemfiles work when `BUNDLE_BIN` is set (bundler/bundler#5847, @segiddins)
  - avoid using the old dependency API when there are no changes to the compact index files (bundler/bundler#5373, @greysteil)
  - fail gracefully when the full index serves gemspecs with invalid dependencies (bundler/bundler#5797, @segiddins)
  - support installing gemfiles that use `eval_gemfile`, `:path` gems with relative paths, and `--deployment` simultaneously (@NickLaMuro)
  - `bundle config` will print settings as the type they are interpreted as (@segiddins)
  - respect the `no_proxy` environment variable when making network requests (bundler/bundler#5781, @jakauppila)
  - commands invoked with `--verbose` will not have default flags printed (@segiddins)
  - allow `bundle viz` to work when another gem has a requirable `grapviz` file (bundler/bundler#5707, @segiddins)
  - ensure bundler puts activated gems on the `$LOAD_PATH` in a consistent order (bundler/bundler#5696, @segiddins)