### PR TITLE
Update RC2 bundler version

### DIFF
--- a/rc1/Dockerfile
+++ b/rc1/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex \
   # install app dependencies
   && DEBIAN_FRONTEND=noninteractive apt-get install git nodejs imagemagick file -y
 
-ENV BUNDLER_VERSION=1.15.1
+ENV BUNDLER_VERSION=1.15.2
 
 RUN set -ex \
   # install bundler and clear caches

--- a/rc2/Dockerfile
+++ b/rc2/Dockerfile
@@ -2,7 +2,7 @@ FROM dleemoo/app-2.3.1:latest
 
 MAINTAINER Leonardo Lobo Lima <dleemoo@gmail.com>
 
-ENV BUNDLER_VERSION=1.15.3 \
+ENV BUNDLER_VERSION=1.15.4 \
     PG_DOWNLOAD_SHA256=a6856099959bfff7cf0889b0e637b0f04642e8a9e8cbfa3f92555a03ef3b2448
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Keeping up-to-date with production.

Heroku is using Bundler 1.15.2 (`heroku run bundler --version -r production`).

Our app in AWS is using the latest, 1.15.4.